### PR TITLE
feat: Add negative test cases and invalid PHP files for Moodle Plugin CI Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,20 @@ jobs:
   negative-tests:
     runs-on: ubuntu-22.04   
 
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
     name: Test failure case
     steps:
       - name: Checkout action code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           plugin-path: ./plugin
 
   negative-tests:
-    runs-on: ubuntu-22.04   
+    runs-on: ubuntu-22.04
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
 
     name: Moodle CI PHP ${{ matrix.php }} Moodle ${{ matrix.moodle }} DB ${{ matrix.db }}
     steps:
+      - name: Checkout action code
+        uses: actions/checkout@v4
+
       - name: Checkout plugin code
         uses: actions/checkout@v4
         with:
@@ -66,10 +69,10 @@ jobs:
 
   negative-tests:
     runs-on: ubuntu-22.04   
-    
+
     name: Test failure case
     steps:
-      - name: Checkout plugin code
+      - name: Checkout action code
         uses: actions/checkout@v4
 
       - name: Run Moodle Plugin CI (expecting failure)
@@ -78,7 +81,7 @@ jobs:
           php-version: 8.3
           moodle-branch: MOODLE_500_STABLE
           database: pgsql
-          plugin-path: ./tests/fixtures/invaliud
+          plugin-path: ./tests/fixtures/invalid
         continue-on-error: true
 
       - name: Verify it failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - 'releases/*'
 
 jobs:
-  test:
+  positive-tests:
     runs-on: ubuntu-22.04
 
     services:
@@ -47,7 +47,6 @@ jobs:
             db: mariadb
 
     name: Moodle CI PHP ${{ matrix.php }} Moodle ${{ matrix.moodle }} DB ${{ matrix.db }}
-
     steps:
       - name: Checkout plugin code
         uses: actions/checkout@v4
@@ -58,10 +57,36 @@ jobs:
           path: plugin
 
       - name: Run Moodle CI on external repo
-        uses: GFrancV/moodle-plugin-ci-action@main
+        uses: ./ # Use the local action
         with:
           php-version: ${{ matrix.php }}
           moodle-branch: ${{ matrix.moodle }}
           database: ${{ matrix.db }}
           plugin-path: ./plugin
+
+  negative-tests:
+    runs-on: ubuntu-22.04   
+    
+    name: Test failure case
+    steps:
+      - name: Checkout plugin code
+        uses: actions/checkout@v4
+
+      - name: Run Moodle Plugin CI (expecting failure)
+        uses: ./ # Use the local action
+        with:
+          php-version: 8.3
+          moodle-branch: MOODLE_500_STABLE
+          database: pgsql
+          plugin-path: ./tests/fixtures/invaliud
+        continue-on-error: true
+
+      - name: Verify it failed
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "Expected failure but the action succeeded"
+            exit 1
+          else
+            echo "Action failed as expected"
+          fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Verify it failed
         run: |
-          if [ "${{ job.status }}" = "success" ]; then
+          if [ "${{ steps.run_ci.outcome }}" = "success" ]; then
             echo "Expected failure but the action succeeded"
             exit 1
           else

--- a/tests/fixtures/invalid/lib.php
+++ b/tests/fixtures/invalid/lib.php
@@ -1,0 +1,6 @@
+<?php
+
+// Sintaxis inválida para disparar error.
+function my_broken_function( {
+    echo "missing parenthesis";
+}

--- a/tests/fixtures/invalid/lib.php
+++ b/tests/fixtures/invalid/lib.php
@@ -1,6 +1,6 @@
 <?php
 
-// Sintaxis inválida para disparar error.
+// Invalid syntax to trigger error.
 function my_broken_function( {
     echo "missing parenthesis";
 }

--- a/tests/fixtures/invalid/psr_violation.php
+++ b/tests/fixtures/invalid/psr_violation.php
@@ -1,0 +1,4 @@
+<?php
+class bad_className {
+    function BADmethodNAME() {}
+}

--- a/tests/fixtures/invalid/syntax_error.php
+++ b/tests/fixtures/invalid/syntax_error.php
@@ -1,0 +1,2 @@
+<?php
+echo "missing semicolon"

--- a/tests/fixtures/invalid/version.php
+++ b/tests/fixtures/invalid/version.php
@@ -1,0 +1,6 @@
+<?php
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'mod_invalid';
+$plugin->version   = 2025091700;
+$plugin->requires  = 2022041900; // Moodle 4.0 release.


### PR DESCRIPTION
This pull request introduces a new set of negative tests to the GitHub Actions workflow, ensuring that the Moodle Plugin CI action correctly handles invalid plugin code by failing as expected. It also refactors the workflow job names for clarity and switches CI execution to use the local action implementation. The most important changes are grouped below:

**Workflow Enhancements and Refactoring:**

* Added a `negative-tests` job to `.github/workflows/test.yml` that runs the CI action on intentionally invalid plugin code, verifying that failures are correctly detected.
* Renamed the main test job from `test` to `positive-tests` for improved clarity in the workflow.
* Updated the CI action usage in both jobs to reference the local action implementation rather than an external repository.

**Test Fixtures for Negative Testing:**

* Added several invalid plugin files under `tests/fixtures/invalid/`:
  - `lib.php` with a syntax error (missing parenthesis).
  - `syntax_error.php` missing a semicolon.
  - `psr_violation.php` with PSR naming violations.
  - `version.php` with minimal valid plugin metadata.

These changes collectively improve CI reliability by ensuring the action fails for broken plugins and clarify the workflow structure.