### PR TITLE
fix: Update action.yml to correct branding color and handle database input in install command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Moodle Plugin CI'
 author: 'GFrancV'
 description: 'GitHub Action for Moodle Plugin Continuous Integration. Run moodle-plugin-ci for Moodle plugins with PHP & DB matrix.'
 branding:
-  color: 'yellow'
+  color: 'green'
   icon: 'check-circle'
 
 inputs:
@@ -17,7 +17,7 @@ inputs:
   database:
     description: 'Database to use: pgsql or mariadb'
     required: false
-    default: 'pgsql'
+    default: null
   plugin-path:
     description: 'Path to the Moodle plugin to test'
     required: false
@@ -42,7 +42,13 @@ runs:
 
     - name: Run moodle-plugin-ci install
       run: |
-        moodle-plugin-ci install --plugin ${{ inputs.plugin-path }} --db-host=127.0.0.1
+        if [ -n "${{ inputs.database }}" ]; then
+          echo "Running with database ${{ inputs.database }}"
+          moodle-plugin-ci install --plugin ${{ inputs.plugin-path }} --db-host=127.0.0.1
+        else
+          echo "Running without database"
+          moodle-plugin-ci install --plugin ${{ inputs.plugin-path }}
+        fi
       env:
         DB: ${{ inputs.database }}
         MOODLE_BRANCH: ${{ inputs.moodle-branch }}

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Run moodle-plugin-ci install
       run: |
-        if [ -n "${{ inputs.database }}" ]; then
+        if [ "${{ inputs.database }}" != "null" ]; then
           echo "Running with database ${{ inputs.database }}"
           moodle-plugin-ci install --plugin ${{ inputs.plugin-path }} --db-host=127.0.0.1
         else


### PR DESCRIPTION
This pull request updates the `action.yml` configuration for the Moodle Plugin CI GitHub Action. The main changes improve the flexibility of database selection and clarify the action's branding.

Branding update:

* Changed the branding color from yellow to green to better reflect the status or theme of the action.

Database input improvements:

* Set the default value of the `database` input to `null`, allowing users to opt out of specifying a database and making the input optional.
* Updated the install step to conditionally run with or without the database parameter, depending on whether the `database` input is provided. This makes the action more adaptable for different plugin testing scenarios.