### PR TITLE
6 update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,28 +43,39 @@ Executes a comprehensive suite of checks:
 | --- | --- | --- | --- |
 | php-version | Version of PHP to use | `false` | 8.3 |
 | moodle-branch | Moodle branch to test against | `false` | MOODLE_500_STABLE |
-| database | Database to use: pgsql or mariadb | `false` | pgsql |
+| database | Database to use: pgsql or mariadb | `false` | null |
 | plugin-path | Path to the Moodle plugin to test | `false` | ./ |
 
 ## Usage
 
 ### Basic usage (without a database)
 
+This assumes that the plugin code is located in the root directory. For this, the action [checkout@v4](https://github.com/marketplace/actions/checkout) is used to clone the current repository.
+
 ```yml
-name: Test for Moodle plugin in version 5.0 to php 8.3
+name: Test Moodle plugin (no database)
 
 jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - name: Moodle CI PHP 8.3 Moodle 5.0 DB pgsql
+      - name: Checkout action code
+        uses: actions/checkout@v4
+
+      - name: Moodle CI PHP 8.3 Moodle 5.0
         uses: gfrancv/moodle-plugin-ci-action@v1
+        with:
+          php-version: 8.3
+          moodle-branch: MOODLE_500_STABLE
 ```
+> Note: It is important to checkout your plugin repository before running the action. The action needs access to the plugin files, so make sure to use actions/checkout@v4 (or a similar checkout step) to clone your repository into the workflow workspace.
 
 ### Basic usage (with database)
 
+This assumes that the plugin code is located in the root directory.
+
 ```yml
-name: Test for Moodle plugin in version 5.0 to php 8.3
+name: Test Moodle plugin (with database)
 
 jobs:
   test:
@@ -77,7 +88,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
-      # Or .
+      # Or 
       mariadb:
         image: mariadb:10.11
         env:
@@ -85,28 +96,47 @@ jobs:
         ports:
           - 3306:3306
     steps:
-      - name: Moodle CI PHP 8.3 Moodle 5.0 DB pgsql
+      - name: Checkout action code
+        uses: actions/checkout@v4
+
+      - name: Moodle CI PHP 8.3 Moodle 5.0 DB mariadb
         uses: gfrancv/moodle-plugin-ci-action@v1
+        with: 
+          php-version: 8.3
+          moodle-branch: MOODLE_500_STABLE
+          database: mariadb
 ```
 
 ### Advanced use for multiple versions
+
 ```yml
-name: Test for Moodle plugin
+name: Test Moodle plugin (matrix)
 
 jobs:
   test:
     runs-on: ubuntu-22.04
-
+    services: 
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+          
     strategy:
       matrix:
         include:
           - php: '8.2'
             moodle: 'MOODLE_500_STABLE'
-            db: pgsql
+            db: mariadb
           - php: '8.3'
             moodle: 'MOODLE_500_STABLE'
             db: mariadb
+
     steps:
+      - name: Checkout action code
+        uses: actions/checkout@v4
+
       - name: Moodle CI PHP ${{ matrix.php }} Moodle ${{ matrix.moodle }} DB ${{ matrix.db }}
         uses: gfrancv/moodle-plugin-ci-action@v1
         with:
@@ -120,6 +150,8 @@ jobs:
 Ensure that your plugin repository includes a `version.php` file with the appropriate `$plugin->supported` range to align with the Moodle versions being tested.
 
 This action is intended to be used within a GitHub Actions workflow in your plugin repository.
+
+It is important to checkout your plugin repository before running the action. The action needs access to the plugin files, so make sure to use actions/checkout@v4 (or a similar checkout step) to clone your repository into the workflow workspace.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # Moodle Plugin CI Action
 
+[![Test](https://img.shields.io/github/actions/workflow/status/GFrancV/moodle-plugin-ci-action/test.yml?style=for-the-badge&label=Test&logo=github)](https://GitHub.com/GFrancV/moodle-plugin-ci-action/tags/)
+[![GitHub tag](https://img.shields.io/github/tag/GFrancV/moodle-plugin-ci-action.svg?style=for-the-badge&logo=github)](https://GitHub.com/GFrancV/moodle-plugin-ci-action/tags/)
+![Moodle](https://img.shields.io/badge/^4.4-1000?style=for-the-badge&logo=Moodle&logoColor=ffffff&labelColor=gray&color=f98012&label=Moodle)
+
 <a href="#description">Description</a>
 •
 <a href="#params">Params</a>
@@ -12,6 +16,7 @@
 •
 <a href="#license">License</a>
 </div>
+
 
 ## Description
 
@@ -118,4 +123,4 @@ This action is intended to be used within a GitHub Actions workflow in your plug
 
 ## License
 
-The scripts and documentation in this project are released under the MIT License
+The scripts and documentation in this project are released under the [MIT License](LICENSE)


### PR DESCRIPTION
This pull request updates the `README.md` to improve clarity and usability for setting up the Moodle Plugin CI GitHub Action. The changes focus on making the documentation easier to follow, highlighting required setup steps, and providing clearer usage examples, especially regarding repository checkout and database configuration.

**Documentation improvements:**

* Added badges for build status, tags, and Moodle compatibility at the top of `README.md` for better visibility.
* Enhanced usage instructions to emphasize the importance of running `actions/checkout@v4` before the CI action, ensuring plugin files are available in the workflow. This is now clearly stated in multiple sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R154-R158)

**Usage examples and configuration:**

* Updated example workflows to explicitly include a checkout step and clarified plugin location assumptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R139)
* Changed the default database value in the parameters table to `null` and improved database setup instructions for both PostgreSQL and MariaDB. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R139)
* Improved license section to link directly to the MIT License file.